### PR TITLE
Sync frequency fields

### DIFF
--- a/src/napari_phasors/_synthetic_generator.py
+++ b/src/napari_phasors/_synthetic_generator.py
@@ -75,7 +75,7 @@ def make_intensity_layer_with_phasors(
     from phasorpy.phasor import phasor_from_signal
 
     if harmonic is None:
-        harmonic = 1
+        harmonic = [1]
     mean_intensity_image, G_image, S_image = phasor_from_signal(
         raw_flim_data, axis=axis, harmonic=harmonic
     )

--- a/src/napari_phasors/_tests/test_calibration_tab.py
+++ b/src/napari_phasors/_tests/test_calibration_tab.py
@@ -454,21 +454,5 @@ def test_on_image_layer_changed_with_frequency(make_napari_viewer):
     test_layer.metadata["settings"] = {"frequency": 80}
     viewer.add_layer(test_layer)
 
-    widget._on_image_layer_changed()
+    parent._sync_frequency_inputs_from_metadata()
     assert widget.calibration_widget.frequency_input.text() == "80"
-
-
-def test_on_image_layer_changed_no_layer(make_napari_viewer):
-    """Test _on_image_layer_changed with no layer selected."""
-    viewer = make_napari_viewer()
-    parent = PlotterWidget(viewer)
-    parent.image_layer_with_phasor_features_combobox = Mock()
-    parent.image_layer_with_phasor_features_combobox.currentText.return_value = (
-        ""
-    )
-
-    widget = parent.calibration_tab
-
-    # Should return early without error
-    result = widget._on_image_layer_changed()
-    assert result is None

--- a/src/napari_phasors/_tests/test_utils.py
+++ b/src/napari_phasors/_tests/test_utils.py
@@ -118,58 +118,22 @@ def test_colormap_to_dict():
 
 def test_update_frequency_in_metadata(make_napari_viewer):
     """Test update_frequency_in_metadata function."""
-    # Create a mock widget structure
-    mock_widget = Mock(spec=QWidget)
+    # Create a test image layer
+    raw_flim_data = make_raw_flim_data(n_time_bins=10)
+    intensity_layer = make_intensity_layer_with_phasors(raw_flim_data)
 
-    # Create a real viewer and layer
-    viewer = make_napari_viewer()
-    raw_flim_data = make_raw_flim_data(shape=(5, 5))
-    intensity_layer = make_intensity_layer_with_phasors(
-        raw_flim_data, harmonic=[1, 2]
-    )
-    viewer.add_layer(intensity_layer)
-
-    # Setup mock widget with viewer
-    mock_widget.viewer = viewer
-
-    # Mock the combobox
-    mock_combobox = Mock(spec=QComboBox)
-    mock_combobox.currentText.return_value = intensity_layer.name
-    mock_widget.image_layer_with_phasor_features_combobox = mock_combobox
-
-    # Mock the calibration tab and frequency input
-    mock_calibration_tab = Mock()
-    mock_calibration_widget = Mock()
-    mock_frequency_input = Mock(spec=QLineEdit)
-    mock_calibration_widget.frequency_input = mock_frequency_input
-    mock_calibration_tab.calibration_widget = mock_calibration_widget
-    mock_widget.calibration_tab = mock_calibration_tab
-
-    # Test updating frequency
+    # Test updating frequency when no settings exist
     test_frequency = 80.0
-
-    # Ensure layer has no settings initially
     if "settings" in intensity_layer.metadata:
         del intensity_layer.metadata["settings"]
-
-    update_frequency_in_metadata(mock_widget, test_frequency)
-
-    # Check that settings were created and frequency was set
+    update_frequency_in_metadata(intensity_layer, test_frequency)
     assert "settings" in intensity_layer.metadata
     assert "frequency" in intensity_layer.metadata["settings"]
     assert intensity_layer.metadata["settings"]["frequency"] == test_frequency
 
-    # Check that the frequency input was updated
-    mock_frequency_input.setText.assert_called_once_with(str(test_frequency))
-
     # Test updating frequency when settings already exist
     intensity_layer.metadata["settings"]["existing_setting"] = "test"
-    mock_frequency_input.reset_mock()
-
     new_frequency = 120.0
-    update_frequency_in_metadata(mock_widget, new_frequency)
-
-    # Check that frequency was updated and existing settings preserved
+    update_frequency_in_metadata(intensity_layer, new_frequency)
     assert intensity_layer.metadata["settings"]["frequency"] == new_frequency
     assert intensity_layer.metadata["settings"]["existing_setting"] == "test"
-    mock_frequency_input.setText.assert_called_once_with(str(new_frequency))

--- a/src/napari_phasors/_utils.py
+++ b/src/napari_phasors/_utils.py
@@ -9,6 +9,10 @@ import numpy as np
 from napari.layers import Image
 from phasorpy.phasor import phasor_filter_median, phasor_threshold
 from qtpy.QtWidgets import QWidget
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import napari
 
 
 def apply_filter_and_threshold(
@@ -103,18 +107,10 @@ def colormap_to_dict(colormap, num_colors=10, exclude_first=True):
 
 
 def update_frequency_in_metadata(
-    parent_widget: QWidget,
+    image_layer: "napari.layers.Image",
     frequency: float,
 ):
     """Update the frequency in the layer metadata."""
-    layer = parent_widget.viewer.layers[
-        parent_widget.image_layer_with_phasor_features_combobox.currentText()
-    ]
-    if "settings" not in layer.metadata.keys():
-        layer.metadata["settings"] = {}
-    layer.metadata["settings"]["frequency"] = frequency
-    parent_widget.calibration_tab.calibration_widget.frequency_input.setText(
-        str(frequency)
-    )
-    # parent_widget.lifetime_tab.frequency_input.setText(str(frequency))
-    # parent_widget.fret_tab.frequency_input.setText(str(frequency))
+    if "settings" not in image_layer.metadata.keys():
+        image_layer.metadata["settings"] = {}
+    image_layer.metadata["settings"]["frequency"] = frequency

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -71,22 +71,6 @@ class CalibrationWidget(QWidget):
                 layer.name
             )
 
-    def _on_image_layer_changed(self):
-        """Handle changes to the image layer selection."""
-        layer_name = (
-            self.parent_widget.image_layer_with_phasor_features_combobox.currentText()
-        )
-        if layer_name == "":
-            return
-        layer_metadata = self.viewer.layers[layer_name].metadata
-        if (
-            'settings' in layer_metadata.keys()
-            and 'frequency' in layer_metadata['settings'].keys()
-        ):
-            self.calibration_widget.frequency_input.setText(
-                str(layer_metadata['settings']['frequency'])
-            )
-
     def _update_button_state(self):
         """Update button text and state based on current layer's calibration status."""
         sample_name = (

--- a/src/napari_phasors/calibration_tab.py
+++ b/src/napari_phasors/calibration_tab.py
@@ -120,7 +120,9 @@ class CalibrationWidget(QWidget):
             show_error("Select sample and calibration layers")
             return
 
-        sample_metadata = self.viewer.layers[sample_name].metadata
+        sample_layer = self.viewer.layers[sample_name]
+        sample_metadata = sample_layer.metadata
+        calibration_layer = self.viewer.layers[calibration_name]
 
         # Check if layer is already calibrated
         if (
@@ -144,21 +146,17 @@ class CalibrationWidget(QWidget):
             show_error("Enter reference lifetime")
             return
         frequency = float(frequency)
-        update_frequency_in_metadata(self.parent_widget, frequency)
+        update_frequency_in_metadata(sample_layer, frequency)
         lifetime = float(lifetime)
         sample_phasor_data = sample_metadata[
             "phasor_features_labels_layer"
         ].features
         harmonics = np.unique(sample_phasor_data["harmonic"])
         original_mean_shape = sample_metadata["original_mean"].shape
-        calibration_phasor_data = (
-            self.viewer.layers[calibration_name]
-            .metadata["phasor_features_labels_layer"]
-            .features
-        )
-        calibration_mean = self.viewer.layers[calibration_name].metadata[
-            "original_mean"
-        ]
+        calibration_phasor_data = calibration_layer.metadata[
+            "phasor_features_labels_layer"
+        ].features
+        calibration_mean = calibration_layer.metadata["original_mean"]
         calibration_harmonics = np.unique(calibration_phasor_data["harmonic"])
         if not np.array_equal(harmonics, calibration_harmonics):
             show_error(

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -320,7 +320,7 @@ class PlotterWidget(QWidget):
         self.tab_widget.addTab(self.calibration_tab, "Calibration")
         # Broadcast frequency changes from the calibration tab to all tabs
         self.calibration_tab.calibration_widget.frequency_input.textEdited.connect(
-            self._broadcast_frequency_value_accross_tabs
+            self._broadcast_frequency_value_across_tabs
         )
 
     def _create_filter_tab(self):
@@ -645,9 +645,9 @@ class PlotterWidget(QWidget):
         frequency = self._get_frequency_from_layer()
         if frequency is None:
             return
-        self._broadcast_frequency_value_accross_tabs(str(frequency))
+        self._broadcast_frequency_value_across_tabs(str(frequency))
 
-    def _broadcast_frequency_value_accross_tabs(self, value):
+    def _broadcast_frequency_value_across_tabs(self, value):
         """
         Broadcast the frequency value to all relevant input fields.
         """

--- a/src/napari_phasors/plotter.py
+++ b/src/napari_phasors/plotter.py
@@ -190,6 +190,10 @@ class PlotterWidget(QWidget):
         self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
             self.on_labels_layer_with_phasor_features_changed
         )
+        # Update all frequency widgets from layer metadata if layer changes
+        self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
+            self._sync_frequency_inputs_from_metadata
+        )
         self.plotter_inputs_widget.semi_circle_checkbox.stateChanged.connect(
             self.on_toggle_semi_circle
         )
@@ -314,9 +318,9 @@ class PlotterWidget(QWidget):
         """Create the Calibration tab."""
         self.calibration_tab = CalibrationWidget(self.viewer, parent=self)
         self.tab_widget.addTab(self.calibration_tab, "Calibration")
-
-        self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
-            self.calibration_tab._on_image_layer_changed
+        # Broadcast frequency changes from the calibration tab to all tabs
+        self.calibration_tab.calibration_widget.frequency_input.textEdited.connect(
+            self._broadcast_frequency_value_accross_tabs
         )
 
     def _create_filter_tab(self):
@@ -636,6 +640,21 @@ class PlotterWidget(QWidget):
 
         return None
 
+    def _sync_frequency_inputs_from_metadata(self):
+        """Sync the frequency widget input fields with metadata."""
+        frequency = self._get_frequency_from_layer()
+        if frequency is None:
+            return
+        self._broadcast_frequency_value_accross_tabs(str(frequency))
+
+    def _broadcast_frequency_value_accross_tabs(self, value):
+        """
+        Broadcast the frequency value to all relevant input fields.
+        """
+        self.calibration_tab.calibration_widget.frequency_input.setText(value)
+        # widget.lifetime_tab.lifetime_widget.frequency_input.setText(value)
+        # widget.fret_tab.fret_widget.frequency_input.setText(value)
+
     def _redefine_axes_limits(self, ensure_full_circle_displayed=True):
         """
         Redefine axes limits based on the data plotted in the canvas widget.
@@ -851,10 +870,13 @@ class PlotterWidget(QWidget):
         It also updates `_labels_layer_with_phasor_features` attribute with the
         Labels layer in the metadata of the selected image layer.
         """
-        # Temporarily disconnect the signal to prevent double execution
+        # Temporarily disconnect the signals to prevent double execution
         try:
             self.image_layer_with_phasor_features_combobox.currentIndexChanged.disconnect(
                 self.on_labels_layer_with_phasor_features_changed
+            )
+            self.image_layer_with_phasor_features_combobox.currentIndexChanged.disconnect(
+                self._sync_frequency_inputs_from_metadata
             )
         except TypeError:
             # Signal wasn't connected, ignore
@@ -877,9 +899,12 @@ class PlotterWidget(QWidget):
             layer = self.viewer.layers[layer_name]
             layer.events.name.connect(self.reset_layer_choices)
 
-        # Reconnect the signal
+        # Reconnect the signals
         self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
             self.on_labels_layer_with_phasor_features_changed
+        )
+        self.image_layer_with_phasor_features_combobox.currentIndexChanged.connect(
+            self._sync_frequency_inputs_from_metadata
         )
 
         # Only call the method if the selection actually changed or if it's the first item


### PR DESCRIPTION
Hi @bruno-pannunzio ,

These changes were aimed initially to simplify the `_utils.update_frequency_in_metadata` function, to receive a layer instead of a widget. 

Then, I thought of always relying on the layer metadata for feeding frequency and update all widget fields with that value (if no frequency  in the metadata, the fields start empty). This was done by connecting the combobox with the sample layer to the `_sync_frequency_inputs_from_metadata` method, which gets the frequency from the layer metadata and broadcasts it to all widgets with the `.frequency_input` field (currently only the `calibration_widget`) by calling `_broadcast_frequency_value_across_tabs`.

If the user manually types values in one of these fields, all the other fields will get updated because I connected `.frequency_input.textEdited` to `_broadcast_frequency_value_across_tabs`. This does **not** update the metadata yet. The frequency in the metadata is only updated if the user clicks on the `Calibrate` button. Notice that [QLineEdit.textEdited](https://doc.qt.io/qt-6/qlineedit.html#textEdited), unlike `.textCahnged`, does not emit a signal if the value is changed from code, which is what we want to avoid an infinite loop.
 
If you like these changes, I believe they will be easily applicable to the new tabs. I also updated the tests.

Best,
Marcelo